### PR TITLE
Added an option to not throw an error on invalid token.

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -79,9 +79,10 @@ class JWS extends JWT
      * Creates an instance of a JWS from a JWT.
      * 
      * @param string $jwsTokenString
+     * @param string $error If true or undefined, throws an error on invalid token.
      * @return Namshi\JOSE\JWS
      */
-    public static function load($jwsTokenString)
+    public static function load($jwsTokenString, $error = true)
     {
         $parts = explode('.', $jwsTokenString);
         
@@ -98,7 +99,11 @@ class JWS extends JWT
             }
         }
         
-        throw new InvalidArgumentException(sprintf('The token "%s" is an invalid JWS', $jwsTokenString));
+        if ($error) {
+            throw new InvalidArgumentException(sprintf('The token "%s" is an invalid JWS', $jwsTokenString));
+        } else {
+            return false;
+        }
     }
     
     /**


### PR DESCRIPTION
Fixes #5 

I also think that this should be the default option—why would you want your application to throw an actual error when user specified input is bad?—but that would probably break backwards compatibility.
