### PR TITLE
Base64 encoder/decoder and tests

### DIFF
--- a/src/Namshi/JOSE/Base64.php
+++ b/src/Namshi/JOSE/Base64.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Namshi\JOSE;
+
+/**
+ * Encode and Decode in Base64 Url Safe.
+ */
+class Base64
+{
+    public static function encode($data)
+    {
+        return strtr(rtrim(base64_encode($data), '='), '+/', '-_');
+    }
+
+    public static function decode($data)
+    {
+        return base64_decode(strtr($data, '-_', '+/'));
+    }
+}

--- a/src/Namshi/JOSE/JWT.php
+++ b/src/Namshi/JOSE/JWT.php
@@ -2,6 +2,8 @@
 
 namespace Namshi\JOSE;
 
+use Namshi\JOSE\Base64;
+
 /**
  * Class representing a JSON Web Token.
  */
@@ -18,8 +20,8 @@ class JWT
      */
     public function __construct(array $payload, array $header)
     {
-        $this->payload = $payload;
-        $this->header  = $header;
+        $this->setPayload($payload);
+        $this->setHeader($header);
     }
 
     /**
@@ -29,8 +31,8 @@ class JWT
      */
     public function generateSigninInput()
     {
-        $base64payload  = base64_encode(json_encode($this->getPayload()));
-        $base64header   = base64_encode(json_encode($this->getHeader()));
+        $base64header   = Base64::encode(json_encode($this->getHeader()));
+        $base64payload  = Base64::encode(json_encode($this->getPayload()));
 
         return sprintf("%s.%s", $base64header, $base64payload);
     }
@@ -78,5 +80,23 @@ class JWT
     public function setHeader(array $header)
     {
         $this->header = $header;
+    }
+
+    /**
+     * Checks whether the token is expired.
+     *
+     * @return bool
+     */
+    protected function isExpired()
+    {
+        $payload = $this->getPayload();
+
+        if (isset($payload['exp']) && is_numeric($payload['exp'])) {
+            $now            = new \DateTime('now');
+
+            return ($now->format('U') - $payload['exp']) > 0;
+        }
+
+        return false;
     }
 }

--- a/tests/Namshi/JOSE/Test/Base64Test.php
+++ b/tests/Namshi/JOSE/Test/Base64Test.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Namshi\JOSE\Test;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Namshi\JOSE\Base64;
+
+class Base64Test extends TestCase
+{
+    public function testEncoderAndDecoder() {
+
+        $data = json_encode(array(
+            'foo' => 'bar',
+            'baz' => 'plic',
+            'false' => true,
+            'true' => 'false',
+            'good' => 'bad',
+        ));
+
+        $encodedData = Base64::encode($data);
+        $decodedData = Base64::decode($encodedData);
+
+        $this->assertEquals($data, $decodedData);
+        $this->assertEquals($data, $decodedData);
+        $this->assertRegExp('/^[a-zA-Z0-9+\/]+$/', $encodedData);
+    }
+
+    public function testDecoderWithTrailingEqualSign() {
+
+        $data = 'eyJhbGciOiJ0ZXN0In0=';
+
+        $decodedData = Base64::decode($data);
+        $encodedData = Base64::encode($decodedData);
+
+        $this->assertEquals('{"alg":"test"}', $decodedData);
+        $this->assertNotEquals($data, $encodedData);
+        $this->assertRegExp('/^[a-zA-Z0-9+\/]+$/', $encodedData);
+    }
+}

--- a/tests/Namshi/JOSE/Test/JWSTest.php
+++ b/tests/Namshi/JOSE/Test/JWSTest.php
@@ -98,4 +98,26 @@ class JWSTest extends TestCase
     {
         JWS::load('test', true);
     }
+
+    public function testTokenWithoutSignature()
+    {
+        $token = new JWS('test');
+        $this->assertNull($token->getSignature());
+    }
+
+    public function testTokenWithoutType()
+    {
+        $token = new JWS('test');
+        $header = $token->getHeader();
+
+        $this->assertEquals($header['typ'], 'JWS');
+    }
+
+    public function testTokenWithType()
+    {
+        $token = new JWS('test', 'foo');
+        $header = $token->getHeader();
+
+        $this->assertEquals($header['typ'], 'foo');
+    }
 }

--- a/tests/Namshi/JOSE/Test/JWTTest.php
+++ b/tests/Namshi/JOSE/Test/JWTTest.php
@@ -4,15 +4,53 @@ namespace Namshi\JOSE\Test;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Namshi\JOSE\JWT;
+use Namshi\JOSE\Base64;
 
 class JWTTest extends TestCase
 {
     public function testGenerationOfTheSigninInput()
     {
-        $payload = array('a' => 'b');
+        $payload = array('a' => 'b', 'iat'=>1403033066);
         $header = array('a' => 'b');
         $jwt = new JWT($payload, $header);
 
-        $this->assertEquals(sprintf("%s.%s", base64_encode(json_encode($payload)), base64_encode(json_encode($header))), $jwt->generateSigninInput());
+        $this->assertEquals(sprintf("%s.%s", Base64::encode(json_encode($header)), Base64::encode(json_encode($payload))), $jwt->generateSigninInput());
+    }
+
+    public function testTokenIsNotExpired()
+    {
+        $tomorrow = new \DateTime('tomorrow');
+        $token = new JWT(array('exp'=> $tomorrow->format('U') ), array());
+        $method = self::getMethod('isExpired');
+
+        $this->assertFalse($method->invokeArgs($token,array()));
+    }
+
+    public function testTokenIsExpired()
+    {
+        $yesterday = new \DateTime('yesterday');
+        $token = new JWT(array('exp'=> $yesterday->format('U') ), array());
+        $method = self::getMethod('isExpired');
+
+        $this->assertTrue($method->invokeArgs($token,array()));
+    }
+
+    public function testTokenExpirationDateIsNotDefined()
+    {
+        $token = new JWT(array(), array());
+        $method = self::getMethod('isExpired');
+
+        $this->assertFalse($method->invokeArgs($token,array()));
+    }
+
+    /**
+     * @param string $name
+     */
+    protected static function getMethod($name)
+    {
+        $class = new \ReflectionClass('Namshi\JOSE\JWT');
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method;
     }
 }


### PR DESCRIPTION
As described in the draft 21, section 2 of JWT, the Base64 string should
be safe and trailing = have to be omitted

(http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-21#section-2).
- Base64 class added to encode and decode according to the
  draft
- Tests added: test coverage is now 100%
- Test added to verify that old token will be correctly loaded
- Moved isExpired method from JWS to JWT
- constructors modified to use setHeader and setPayload methods
