### PR TITLE
New setPayload flag to turn off automatic claims addition

### DIFF
--- a/src/Namshi/JOSE/JWT.php
+++ b/src/Namshi/JOSE/JWT.php
@@ -34,9 +34,9 @@ class JWT
      */
     public function __construct(array $payload, array $header)
     {
-        $this->payload = $payload;
-        $this->header  = $header;
-        $this->encoder = new Base64UrlSafeEncoder();
+        $this->setPayload($payload);
+        $this->setHeader($header);
+        $this->setEncoder(new Base64UrlSafeEncoder());
     }
 
     /**
@@ -76,14 +76,17 @@ class JWT
      * Sets the payload of the current JWT.
      *
      * @param array $payload
+     * @param bool $autoClaims
      */
-    public function setPayload(array $payload)
+    public function setPayload(array $payload, $autoClaims = true)
     {
         $this->payload = $payload;
 
-        if (!isset($this->payload['iat'])) {
-            $now                  = new \DateTime('now');
-            $this->payload['iat'] = $now->format('U');
+        if ($autoClaims) {
+            if (!isset($this->payload['iat'])) {
+                $now                  = new \DateTime('now');
+                $this->payload['iat'] = $now->format('U');
+            }
         }
 
         return $this;

--- a/tests/Namshi/JOSE/Test/JWTTest.php
+++ b/tests/Namshi/JOSE/Test/JWTTest.php
@@ -10,12 +10,12 @@ class JWTTest extends TestCase
 {
     public function testGenerationOfTheSigninInput()
     {
-        $payload = array('a' => 'b');
+        $payload = array('b' => 'a', 'iat' => 1421161177);
         $header = array('a' => 'b');
         $jwt = new JWT($payload, $header);
         $encoder = new Base64UrlSafeEncoder();
 
-        $this->assertEquals(sprintf("%s.%s", $encoder->encode(json_encode($payload)), $encoder->encode(json_encode($header))), $jwt->generateSigninInput());
+        $this->assertEquals(sprintf("%s.%s", $encoder->encode(json_encode($header)), $encoder->encode(json_encode($payload))), $jwt->generateSigninInput());
     }
 
     public function testPayload()

--- a/tests/Namshi/JOSE/Test/JWTTest.php
+++ b/tests/Namshi/JOSE/Test/JWTTest.php
@@ -17,4 +17,27 @@ class JWTTest extends TestCase
 
         $this->assertEquals(sprintf("%s.%s", $encoder->encode(json_encode($payload)), $encoder->encode(json_encode($header))), $jwt->generateSigninInput());
     }
+
+    public function testPayload()
+    {
+        $jwt = new JWT(array('a' => 'b'), array());
+        $payload = $jwt->getPayload();
+
+        $this->assertSame($payload['a'], 'b');
+        $this->assertRegExp('/^\d+$/', $payload['iat'], 'iat property has integer value (from construction)');
+
+        $jwt = new JWT(array('a' => 'b'), array());
+        $jwt->setPayload(array('b' => 'a'));
+        $payload = $jwt->getPayload();
+
+        $this->assertSame($payload['b'], 'a');
+        $this->assertRegExp('/^\d+$/', $payload['iat'], 'iat property has integer value (from set)');
+
+        $jwt = new JWT(array('a' => 'b'), array());
+        $jwt->setPayload(array('b' => 'a'), false);
+        $payload = $jwt->getPayload();
+
+        $this->assertSame($payload['b'], 'a');
+        $this->assertFalse(isset($payload['iat']), 'no iat property (from set with auto claim off)');
+    }
 }


### PR DESCRIPTION
Addresses #19.

When providing the payload via the constructor the `iat` property wasn't being added automatically so the payload would be inconsistent in that case so I adjusted that as well. Switched the other properties to use their setters for consistency.

Switching the constructor revealed a couple of issues in the JWTTests so those are fixed and improved a little to hopefully prevent regressions. The test was using the same array structure for both header and payload so the base64 representation was coming out the same, but the order of the concatenation of strings was wrong. So I made it so that they had different array values and fixed the assertion.

Unit tests included for the payload changes, though I still had unrelated breakage for other existing tests. See Namshi\JOSE\Test\Signer\ES256Test::testSigningWorksProperly (and for ES384 and ES512).