### PR TITLE
Explicitly set header in JWS::load

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -105,6 +105,7 @@ class JWS extends JWT
                 $jws = new self($header['alg'], isset($header['typ']) ? $header['typ'] : null);
                 
                 $jws->setEncoder($encoder)
+                    ->setHeader($header)
                     ->setPayload($payload)
                     ->setEncodedSignature($parts[2]);
 

--- a/tests/Namshi/JOSE/Test/JWSTest.php
+++ b/tests/Namshi/JOSE/Test/JWSTest.php
@@ -60,7 +60,7 @@ class JWSTest extends TestCase
         $payload = $jws->getPayload();
         $this->assertEquals('b', $payload['a']);
     }
-    
+
     public function testRestrictingTheAlgorithmsKo()
     {
         $this->jws  = new JWS('HS256');
@@ -70,7 +70,7 @@ class JWSTest extends TestCase
         $this->assertFalse($jws->verify('12345', 'RS256'));
         $this->assertFalse($jws->isValid('12345', 'RS256'));
     }
-    
+
     public function testRestrictingTheAlgorithmsOk()
     {
         $date       = new DateTime('tomorrow');
@@ -201,6 +201,23 @@ class JWSTest extends TestCase
 
         $this->assertFalse($jws->verify($public_key));
 
+    }
+
+    public function testLoadingWithAnyOrderOfHeaders()
+    {
+        $privateKey = openssl_pkey_get_private(SSL_KEYS_PATH . "private.key", self::SSL_KEY_PASSPHRASE);
+        $public_key = openssl_pkey_get_public(SSL_KEYS_PATH . "public.key");
+
+        $header = $this->jws->getHeader();
+        $reversedHeader = array_reverse($header);
+        $this->assertFalse($header === $reversedHeader);
+
+        $this->jws->setHeader($reversedHeader);
+        $this->jws->sign($privateKey);
+
+        $tokenString = $this->jws->getTokenString();
+        $jws = JWS::load($tokenString);
+        $this->assertTrue($reversedHeader === $jws->getHeader());
     }
 
 }


### PR DESCRIPTION
When using the constructor, the header is ordered in its own order, not according to how the provided token may have be ordered. This then causes signature validation to fail because the header has been reordered from what the original token provided.

Example:  My token is created by another service that puts the header in order of [typ, alg].  When JWS::load is used, when the JWS token's constructor is used, it always orders it [alg, typ].  This, now reordered header, is then later json encoded and used in the signature verification, which of course will now fail.

By setting the header to what the token provided, signature verification can now succeed, regardless of the order of the json fields.