### PR TITLE
Pass the password to the key conversion

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -179,7 +179,7 @@ class JWS extends JWT
      */
     protected function getSigner()
     {
-        $signerClass = sprintf("Namshi\\JOSE\\Signer\\$this->encryptionEngine\\%s", $this->header['alg']);
+        $signerClass = sprintf('Namshi\\JOSE\\Signer\\%s\\%s', $this->encryptionEngine, $this->header['alg']);
 
         if (class_exists($signerClass)) {
             return new $signerClass();

--- a/tests/Namshi/JOSE/Test/JWSTest.php
+++ b/tests/Namshi/JOSE/Test/JWSTest.php
@@ -118,6 +118,19 @@ class JWSTest extends TestCase
         $this->assertEquals('b', $payload['a']);
     }
 
+    public function testVerificationRS256KeyAsString()
+    {
+        $privateKey = file_get_contents(TEST_DIR . "/private.key");//, self::SSL_KEY_PASSPHRASE);
+        $this->jws->sign($privateKey, self::SSL_KEY_PASSPHRASE);
+
+        $jws        = JWS::load($this->jws->getTokenString());
+        $public_key = openssl_pkey_get_public(SSL_KEYS_PATH . "public.key");
+        $this->assertTrue($jws->verify($public_key));
+
+        $payload = $jws->getPayload();
+        $this->assertEquals('b', $payload['a']);
+    }
+
     public function testUseOfCustomEncoder()
     {
         $encoder = $this->prophesize('Namshi\JOSE\Base64\Encoder');


### PR DESCRIPTION
For the encryption engine 'SecLib' the password is passed along. This patch implements the same behaviour for the encryption engine 'OpenSLL'.