### PR TITLE
do not escape slashes in json_encoding of jwt components

### DIFF
--- a/src/Namshi/JOSE/JWT.php
+++ b/src/Namshi/JOSE/JWT.php
@@ -56,8 +56,8 @@ class JWT
      */
     public function generateSigninInput()
     {
-        $base64payload = $this->encoder->encode(json_encode($this->getPayload()));
-        $base64header  = $this->encoder->encode(json_encode($this->getHeader()));
+        $base64payload = $this->encoder->encode(json_encode($this->getPayload(), JSON_UNESCAPED_SLASHES));
+        $base64header  = $this->encoder->encode(json_encode($this->getHeader(), JSON_UNESCAPED_SLASHES));
 
         return sprintf("%s.%s", $base64header, $base64payload);
     }

--- a/tests/Namshi/JOSE/Test/JWTTest.php
+++ b/tests/Namshi/JOSE/Test/JWTTest.php
@@ -18,6 +18,16 @@ class JWTTest extends TestCase
         $this->assertEquals(sprintf("%s.%s", $encoder->encode(json_encode($header)), $encoder->encode(json_encode($payload))), $jwt->generateSigninInput());
     }
 
+    public function testGenerationOfTheSigninInputCanHandleSlashes()
+    {
+        $encoder = new Base64UrlSafeEncoder();
+        $json_string = '{"a":"/b/"}';
+        $encoded_json_string = $encoder->encode($json_string);
+        $jwt = new JWT(json_decode($json_string, true), json_decode($json_string, true));
+
+        $this->assertEquals(sprintf("%s.%s", $encoded_json_string, $encoded_json_string), $jwt->generateSigninInput());
+    }
+
     public function testPayload()
     {
         $jwt = new JWT(array('a' => 'b'), array());


### PR DESCRIPTION
Currently when we sign JWTs, we get JSON representations of the HEADER and PAYLOAD, and we escape slashes in that json encoding.

This is problematic because if the payload is originally base64 encoded _without_ escaped slashes, then verification of that JWT will fail.  

If the JWT is generated using this library, then there is no problem because the slashes are escaped before the JWT the header and payload are base64 encoded as well.  However, while using this library in conjunction with other code that does not escape slashes before base64 encoding the payload and header, verification will fail.   

I can see no reason to escape slashes.  This is a pull request to stop escaping slashes in the JWT head and payload before base64 encoding them to be signed.