### PR TITLE
Update phpseclib dependency to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         "ext-pcre": "*",
         "ext-spl": "*",
         "php": ">=5.4.8",
-        "phpseclib/phpseclib": "~0.3"
+        "phpseclib/phpseclib": "~2.0"
     }
 }


### PR DESCRIPTION
There is a stable version of phpseclib, so I guess it would make sense to move from 0.3 to 2.0.

There are 3 tests failing, but they are also failing on the master branch so I think they're not related to this update.