### PR TITLE
Be less strict on phpseclib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
         "ext-pcre": "*",
         "ext-spl": "*",
         "php": ">=5.4.8",
-        "phpseclib/phpseclib": "1.0.0"
+        "phpseclib/phpseclib": "~1.0"
     }
 }


### PR DESCRIPTION
Also, any chance we could upgrade to `~2.0` in the 7.x series?