### PR TITLE
CS fix

### DIFF
--- a/tests/Namshi/JOSE/Test/JWSTest.php
+++ b/tests/Namshi/JOSE/Test/JWSTest.php
@@ -120,7 +120,7 @@ class JWSTest extends TestCase
 
     public function testVerificationRS256KeyAsString()
     {
-        $privateKey = file_get_contents(TEST_DIR.'/private.key');//, self::SSL_KEY_PASSPHRASE);
+        $privateKey = file_get_contents(TEST_DIR.'/private.key');
         $this->jws->sign($privateKey, self::SSL_KEY_PASSPHRASE);
 
         $jws        = JWS::load($this->jws->getTokenString());


### PR DESCRIPTION
Symfony doesn't allow commenting out code and that's the code style you've indicated you wanted in the .styleci.yml config file.

Symfony recommends simply deleting code, since we have git if we need it back.