### PR TITLE
Fixed security floor in hash_equals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
         "ext-spl": "*",
         "php": ">=5.5",
         "phpseclib/phpseclib": "^2.0",
-        "symfony/polyfill-mbstring": "^1.0"
+        "symfony/polyfill-php56": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "ext-pcre": "*",
         "ext-spl": "*",
         "php": ">=5.5",
-        "phpseclib/phpseclib": "2.0.*"
+        "phpseclib/phpseclib": "^2.0",
+        "symfony/polyfill-mbstring": "^1.0"
     }
 }

--- a/src/Namshi/JOSE/Signer/OpenSSL/HMAC.php
+++ b/src/Namshi/JOSE/Signer/OpenSSL/HMAC.php
@@ -31,10 +31,6 @@ abstract class HMAC implements SignerInterface
     {
         $signedInput = $this->sign($input, $key);
 
-        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
-            return hash_equals($signedInput, $signature);
-        }
-
         return $this->timingSafeEquals($signedInput, $signature);
     }
 
@@ -48,25 +44,7 @@ abstract class HMAC implements SignerInterface
      */
     public function timingSafeEquals($known, $input)
     {
-        $knownLength = strlen($known);
-        $inputLength = strlen($input);
-
-        if (\function_exists('mb_strlen')) {
-            $knownLength = \mb_strlen($known, '8bit');
-            $inputLength = \mb_strlen($input, '8bit');
-        }
-
-        $result = 0;
-
-        if ($knownLength !== $inputLength) {
-            return false;
-        }
-
-        for ($i = 0; $i < $inputLength; ++$i) {
-            $result |= (ord($known[$i]) ^ ord($input[$i]));
-        }
-
-        return $result === 0;
+        return hash_equals($known, $input);
     }
 
     /**


### PR DESCRIPTION
Fixed security floor. Always better to rely on a third party secure implementation rather than maintaining a separate one that just recently was noticed to be broken.