### PR TITLE
Signature fix

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -56,7 +56,7 @@ class JWS extends JWT
      */
     public function sign($key, $password = null)
     {
-        $this->signature = $this->getSigner()->sign($this->generateSigninInput(), $key, $password);
+        $this->signature = hex2bin($this->getSigner()->sign($this->generateSigninInput(), $key, $password));
         $this->isSigned = true;
 
         return $this->signature;

--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -56,7 +56,7 @@ class JWS extends JWT
      */
     public function sign($key, $password = null)
     {
-        $this->signature = hex2bin($this->getSigner()->sign($this->generateSigninInput(), $key, $password));
+        $this->signature = $this->getSigner()->sign($this->generateSigninInput(), $key, $password);
         $this->isSigned = true;
 
         return $this->signature;


### PR DESCRIPTION
This fixes signature creation, the presently generated signature doesn't comply with the RFC and is rejected by other applications/libraries. The reason is that the signature is base64 encoded as a string instead of a hexidecimal representation of octets.

Convert signature to binary before base64 encode results in the expected signature as verified against the example in RFC 7515 and the http://jwt.io debugger.

Results may be validated with:
`echo -n "base64_encoded_header.base64_encoded_payload"  | openssl dgst -sha256 -hmac "your_secret" -binary | base64 | tr -- '+=/' '- _'`