### PR TITLE
Json number fix

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -56,7 +56,7 @@ class JWS extends JWT
      */
     public function sign($key, $password = null)
     {
-        $this->signature = $this->getSigner()->sign($this->generateSigninInput(), $key, $password);
+        $this->signature = hex2bin($this->getSigner()->sign($this->generateSigninInput(), $key, $password));
         $this->isSigned = true;
 
         return $this->signature;

--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -56,7 +56,7 @@ class JWS extends JWT
      */
     public function sign($key, $password = null)
     {
-        $this->signature = hex2bin($this->getSigner()->sign($this->generateSigninInput(), $key, $password));
+        $this->signature = $this->getSigner()->sign($this->generateSigninInput(), $key, $password);
         $this->isSigned = true;
 
         return $this->signature;

--- a/src/Namshi/JOSE/JWT.php
+++ b/src/Namshi/JOSE/JWT.php
@@ -55,8 +55,8 @@ class JWT
      */
     public function generateSigninInput()
     {
-        $base64payload = $this->encoder->encode(json_encode($this->getPayload(), JSON_UNESCAPED_SLASHES));
-        $base64header = $this->encoder->encode(json_encode($this->getHeader(), JSON_UNESCAPED_SLASHES));
+        $base64payload = $this->encoder->encode(json_encode($this->getPayload(), JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK));
+        $base64header = $this->encoder->encode(json_encode($this->getHeader(), JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK));
 
         return sprintf('%s.%s', $base64header, $base64payload);
     }


### PR DESCRIPTION
Currently numbers, particularly those for nbf, iat and exp fields are being json encoded as strings which is invalid as per RFC 7519 which requires they be a "JSON numeric value".

This adds the JSON_NUMERIC_CHECK flag to json_encode() so that numbers are treated as numeric values instead of strings.