### PR TITLE
Make ext-openssl and phpseclib optional dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,6 @@
 {
     "name": "namshi/jose",
     "description": "JSON Object Signing and Encryption library for PHP.",
-    "require-dev": {
-        "phpunit/phpunit": "^4.5|^5.0",
-        "satooshi/php-coveralls": "^1.0"
-    },
     "license": "MIT",
     "keywords": ["jws", "jwt", "json", "json web token", "json web signature", "token"],
     "authors": [
@@ -35,6 +31,11 @@
         "ext-spl": "*",
         "php": ">=5.5",
         "symfony/polyfill-php56": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.5|^5.0",
+        "satooshi/php-coveralls": "^1.0",
+        "phpseclib/phpseclib": "^2.0"
     },
     "suggest": {
         "ext-openssl": "Allows to use OpenSSL as crypto engine.",

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,13 @@
         "ext-date": "*",
         "ext-hash": "*",
         "ext-json": "*",
-        "ext-openssl": "*",
         "ext-pcre": "*",
         "ext-spl": "*",
         "php": ">=5.5",
-        "phpseclib/phpseclib": "^2.0",
         "symfony/polyfill-php56": "^1.0"
+    },
+    "suggest": {
+        "ext-openssl": "Allows to use OpenSSL as crypto engine.",
+        "phpseclib/phpseclib": "Allows to use Phpseclib as crypto engine, use version ^2.0."
     }
 }


### PR DESCRIPTION
PR for #88. Please note that this will require a new major version since `phpseclib` would get removed with an update even if it's used in a project. It has to be explicitly required after this PR.