### PR TITLE
Move isExpired from SimpleJWS to JWS

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -187,6 +187,24 @@ class JWS extends JWT
     }
 
     /**
+     * Checks whether the token is expired based on the 'exp' value.
+     *
+     * @return bool
+     */
+    public function isExpired()
+    {
+        $payload = $this->getPayload();
+
+        if (isset($payload['exp']) && is_numeric($payload['exp'])) {
+            $now = new \DateTime('now');
+
+            return ($now->format('U') - $payload['exp']) > 0;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the signer responsible to encrypting / decrypting this JWS.
      *
      * @return SignerInterface

--- a/src/Namshi/JOSE/SimpleJWS.php
+++ b/src/Namshi/JOSE/SimpleJWS.php
@@ -53,23 +53,4 @@ class SimpleJWS extends JWS
     {
         return $this->verify($key, $algo) && !$this->isExpired();
     }
-
-    /**
-     * Checks whether the token is expired based on the 'exp' value.
-     *it.
-     *
-     * @return bool
-     */
-    public function isExpired()
-    {
-        $payload = $this->getPayload();
-
-        if (isset($payload['exp']) && is_numeric($payload['exp'])) {
-            $now = new \DateTime('now');
-
-            return ($now->format('U') - $payload['exp']) > 0;
-        }
-
-        return false;
-    }
 }


### PR DESCRIPTION
I propose this change in order to be able to check if a JWS created from an instance of `Namshi\JOSE\JWS` is expired or not (and not only from SimpleJWS), sort as we can do the check even if using the SecLib encryption engine.

Or is there something in the method that is not directly compatible with the JWS class, or that doesn't make sense to exist into?
ATM I need to duplicate the isExpired method in my project to do this chek on `Namshi\JOSE\JWS` instances.