### PR TITLE
Make SimpleJWS working for SecLib

### DIFF
--- a/src/Namshi/JOSE/SimpleJWS.php
+++ b/src/Namshi/JOSE/SimpleJWS.php
@@ -17,12 +17,12 @@ class SimpleJWS extends JWS
      * @see https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#section-4
      * }
      */
-    public function __construct($header = array())
+    public function __construct($header = array(), $encryptionEngine = 'OpenSSL')
     {
         if (!isset($header['typ'])) {
             $header['typ'] = 'JWS';
         }
-        parent::__construct($header);
+        parent::__construct($header, $encryptionEngine);
     }
 
     /**


### PR DESCRIPTION
As previously discussed in #91, I propose to make the SimpleJWS working with SecLib, in order to take the benefits of `SimpleJWS::isValid` and so on.