### PR TITLE
Fix param type (phpdoc) in JWS::sign

### DIFF
--- a/src/Namshi/JOSE/JWS.php
+++ b/src/Namshi/JOSE/JWS.php
@@ -49,7 +49,7 @@ class JWS extends JWT
     /**
      * Signs the JWS signininput.
      *
-     * @param resource        $key
+     * @param resource|string $key
      * @param optional string $password
      *
      * @return string


### PR DESCRIPTION
In JWS::sign(), the second argument can be either a string or a resource (for SecLib it'll be a string for instance, see the [SignerInterface](https://github.com/namshi/jose/blob/master/src/Namshi/JOSE/Signer/SignerInterface.php) that allows the two types.