### PR TITLE
Updated README by fixing small typo in code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $public_key = openssl_pkey_get_public("/path/to/public.key");
 if ($jws->isValid($public_key, 'RS256')) {
 	$payload = $jws->getPayload();
 
-	echo sprintf("Hey, my JS app just did an action authenticated as user #%s", $payload['id']);
+	echo sprintf("Hey, my JS app just did an action authenticated as user #%s", $payload['uid']);
 }
 ```
 


### PR DESCRIPTION
The example code showing how to create a JWT use a payload containing a `uid` property. Reuse this payload property in the code example that verify the JWT (instead of `id`).