### PR TITLE
Make failed key resources throw informative error

### DIFF
--- a/src/Namshi/JOSE/Signer/OpenSSL/PublicKey.php
+++ b/src/Namshi/JOSE/Signer/OpenSSL/PublicKey.php
@@ -60,7 +60,7 @@ abstract class PublicKey implements SignerInterface
             return $key;
         }
 
-        $resouce = openssl_pkey_get_public($key) ?: openssl_pkey_get_private($key, $password);
+        $resource = openssl_pkey_get_public($key) ?: openssl_pkey_get_private($key, $password);
         if ($resource === false) {
             throw new RuntimeException('Could not read key resource: ' . openssl_error_string());
         }

--- a/src/Namshi/JOSE/Signer/OpenSSL/PublicKey.php
+++ b/src/Namshi/JOSE/Signer/OpenSSL/PublicKey.php
@@ -60,7 +60,11 @@ abstract class PublicKey implements SignerInterface
             return $key;
         }
 
-        return openssl_pkey_get_public($key) ?: openssl_pkey_get_private($key, $password);
+        $resouce = openssl_pkey_get_public($key) ?: openssl_pkey_get_private($key, $password);
+        if ($resource === false) {
+            throw new RuntimeException('Could not read key resource: ' . openssl_error_string());
+        }
+        return $resource;
     }
 
     /**

--- a/tests/Namshi/JOSE/Test/Signer/OpenSSL/KeyFormatTest.php
+++ b/tests/Namshi/JOSE/Test/Signer/OpenSSL/KeyFormatTest.php
@@ -41,12 +41,18 @@ class KeyFormatTest extends TestCase
         $this->assertTrue($this->signer->verify($this->publicKeyResource, $encrypted, 'aaa'));
     }
 
+    /**
+     * @requires PHP 5.6
+     */
     public function testBadStringKeyThrowsException()
     {
         $this->expectException(\RuntimeException::class);
         $this->signer->sign('aaa', $this->badPrivateKeyString);
     }
 
+    /**
+     * @requires PHP 5.6
+     */
     public function testFilePathKeyThrowsException()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Namshi/JOSE/Test/Signer/OpenSSL/KeyFormatTest.php
+++ b/tests/Namshi/JOSE/Test/Signer/OpenSSL/KeyFormatTest.php
@@ -15,6 +15,8 @@ class KeyFormatTest extends TestCase
         $this->publicKeyResource = openssl_pkey_get_public(SSL_KEYS_PATH.'public.key');
         $this->publicKeyString = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDfdZEMQbms3t1oyAjY3kfxw/BN\n5A86fPfi4bZ97TIrIeMkMYTZegRJGm7kt6VI91gz+vgBYwVagNY937vFqru4USQz\nxzrNpAiCPi4SKr6kEy8f57zTlIVtg4pip9B7h55cCTg6tDBxSRKuUayR/phRrD/c\njBs+DMQNOBNkVW1CUQIDAQAB\n-----END PUBLIC KEY-----";
         $this->publicKeyFilePath = SSL_KEYS_PATH.'public-ne.key';
+        $this->badPrivateKeyString = "-----BEGIN PRIVATE KEY-----\nfoo\nbar\n-----END PRIVATE KEY-----";
+        $this->badPrivateKeyFilePath = SSL_KEYS_PATH.'nonexistant.key';
         $this->signer = new RS256();
     }
 
@@ -37,5 +39,17 @@ class KeyFormatTest extends TestCase
         $encrypted = $this->signer->sign('aaa', $this->privateKeyResource);
         $this->assertInternalType('bool', $this->signer->verify($this->publicKeyResource, $encrypted, 'aaa'));
         $this->assertTrue($this->signer->verify($this->publicKeyResource, $encrypted, 'aaa'));
+    }
+
+    public function testBadStringKeyThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->signer->sign('aaa', $this->badPrivateKeyString);
+    }
+
+    public function testFilePathKeyThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->signer->sign('aaa', $this->badPrivateKeyFilePath);
     }
 }

--- a/tests/Namshi/JOSE/Test/Signer/OpenSSL/KeyFormatTest.php
+++ b/tests/Namshi/JOSE/Test/Signer/OpenSSL/KeyFormatTest.php
@@ -42,7 +42,7 @@ class KeyFormatTest extends TestCase
     }
 
     /**
-     * @requires PHP 5.6
+     * @requires PHPUnit 5.4
      */
     public function testBadStringKeyThrowsException()
     {
@@ -51,11 +51,17 @@ class KeyFormatTest extends TestCase
     }
 
     /**
-     * @requires PHP 5.6
+     * @requires PHPUnit 5.4
      */
     public function testFilePathKeyThrowsException()
     {
-        $this->expectException(\RuntimeException::class);
+        if(defined('HHVM_VERSION')) {
+            // in HHVM, openssl_pkey_get_(public|private) throws an error when
+            // passed a file path that cannot be found
+            $this->expectException('PHPUnit_Framework_Error');
+        } else {
+            $this->expectException(\RuntimeException::class);
+        }
         $this->signer->sign('aaa', $this->badPrivateKeyFilePath);
     }
 }


### PR DESCRIPTION
This is in response to an issue raised in tymondesigns/jwt-auth#763. A couple users were attempting to pass in `file://` keys, but having a hard time diagnosing why they would fail. I suggest you utilize `openssl_error_string()` to communicate problems with potential key resources:

At the moment, when keys are passed in as invalid file strings (or potentially other non-resource objects), `PublicKey` fails with the unclear message:
```
Could not create token: openssl_pkey_get_details() expects parameter 1 to be resource, boolean given
```
It would be more helpful if failures to retrieve key resources were communicated directly to the user, so I have `getKeyResource` checking its result before submitting and throwing an exception if it couldn't successfully create a resource.