### PR TITLE
Fixes #33 - iat added to payload should be an int

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Added the ability to set custom properties in the header. Moved automatic inclus
 
 Moved phpseclib and the openssl extension as suggested dependencies.
 
+## Tests
+
+Tests are written using PHPUnit for this library. After doing composer install you can execute the following command to run tests:
+
+```
+./vendor/bin/phpunit
+```
+
 ## Credits
 
 This library has been inspired by the

--- a/src/Namshi/JOSE/SimpleJWS.php
+++ b/src/Namshi/JOSE/SimpleJWS.php
@@ -29,12 +29,13 @@ class SimpleJWS extends JWS
      * Sets the payload of the current JWS with an issued at value in the 'iat' property.
      *
      * @param array $payload
+     *
+     * @return $this
      */
     public function setPayload(array $payload)
     {
         if (!isset($payload['iat'])) {
-            $now = new \DateTime('now');
-            $payload['iat'] = $now->format('U');
+            $payload['iat'] = time();
         }
 
         return parent::setPayload($payload);
@@ -64,10 +65,16 @@ class SimpleJWS extends JWS
     {
         $payload = $this->getPayload();
 
-        if (isset($payload['exp']) && is_numeric($payload['exp'])) {
+        if (isset($payload['exp'])) {
             $now = new \DateTime('now');
 
-            return ($now->format('U') - $payload['exp']) > 0;
+            if (is_int($payload['exp'])) {
+                return ($now->getTimestamp() - $payload['exp']) > 0;
+            }
+
+            if (is_numeric($payload['exp'])) {
+                return ($now->format('U') - $payload['exp']) > 0;
+            }
         }
 
         return false;

--- a/tests/Namshi/JOSE/Test/SimpleJWSTest.php
+++ b/tests/Namshi/JOSE/Test/SimpleJWSTest.php
@@ -24,7 +24,7 @@ class SimpleJWSTest extends TestCase
     public function testConstruction()
     {
         $this->assertSame($this->jws->getHeader(), array('alg' => 'RS256', 'typ' => 'JWS'));
-        $this->assertRegExp('/^\d+$/', $this->jws->getPayload()['iat'], 'iat property has integer value (from construction)');
+        $this->assertTrue(is_int($this->jws->getPayload()['iat']), 'iat property should be integer value (from construction)');
     }
 
     public function testValidationOfAValidSimpleJWS()
@@ -43,6 +43,60 @@ class SimpleJWSTest extends TestCase
         $this->jws->setPayload(array(
             'exp' => $date->format('U'),
         ));
+        $privateKey = openssl_pkey_get_private(SSL_KEYS_PATH.'private.key', self::SSL_KEY_PASSPHRASE);
+        $this->jws->sign($privateKey);
+
+        $jws = SimpleJWS::load($this->jws->getTokenString());
+        $public_key = openssl_pkey_get_public(SSL_KEYS_PATH.'public.key');
+        $this->assertFalse($jws->isValid($public_key, 'RS256'));
+    }
+
+    public function testValidationOfValidSimpleJWSWithStringIat()
+    {
+        $date = new DateTime('tomorrow');
+        $data = array(
+            'a' => 'b',
+            'exp' => $date->format('U'),
+            'iat' => time()
+        );
+        $this->jws->setPayload($data);
+
+        $privateKey = openssl_pkey_get_private(SSL_KEYS_PATH.'private.key', self::SSL_KEY_PASSPHRASE);
+        $this->jws->sign($privateKey);
+
+        $jws = SimpleJWS::load($this->jws->getTokenString());
+        $public_key = openssl_pkey_get_public(SSL_KEYS_PATH.'public.key');
+        $this->assertTrue($jws->isValid($public_key, 'RS256'));
+    }
+
+    public function testValidationOfValidSimpleJWSWithExpAsInt()
+    {
+        $date = new DateTime('tomorrow');
+        $data = array(
+            'a' => 'b',
+            'exp' => $date->getTimestamp(),
+            'iat' => time()
+        );
+        $this->jws->setPayload($data);
+
+        $privateKey = openssl_pkey_get_private(SSL_KEYS_PATH.'private.key', self::SSL_KEY_PASSPHRASE);
+        $this->jws->sign($privateKey);
+
+        $jws = SimpleJWS::load($this->jws->getTokenString());
+        $public_key = openssl_pkey_get_public(SSL_KEYS_PATH.'public.key');
+        $this->assertTrue($jws->isValid($public_key, 'RS256'));
+    }
+
+    public function testValidationOfInvalidSimpleJWSWithExpAsInt()
+    {
+        $date = new DateTime('yesterday');
+        $data = array(
+            'a' => 'b',
+            'exp' => $date->getTimestamp(),
+            'iat' => time()
+        );
+        $this->jws->setPayload($data);
+
         $privateKey = openssl_pkey_get_private(SSL_KEYS_PATH.'private.key', self::SSL_KEY_PASSPHRASE);
         $this->jws->sign($privateKey);
 


### PR DESCRIPTION
- [x] Adds tests to check backwards compatibility added
- [x] Makes exp an integer too
- [x] Supports string as of now for backwards compatibility
- [x] Uses time function instead of $now->getTimestamp()
- [x] Adds tests section in readme