### PR TITLE
stop adding iat in payload (optional claim)

### DIFF
--- a/src/Namshi/JOSE/SimpleJWS.php
+++ b/src/Namshi/JOSE/SimpleJWS.php
@@ -26,22 +26,6 @@ class SimpleJWS extends JWS
     }
 
     /**
-     * Sets the payload of the current JWS with an issued at value in the 'iat' property.
-     *
-     * @param array $payload
-     *
-     * @return $this
-     */
-    public function setPayload(array $payload)
-    {
-        if (!isset($payload['iat'])) {
-            $payload['iat'] = time();
-        }
-
-        return parent::setPayload($payload);
-    }
-
-    /**
      * Checks that the JWS has been signed with a valid private key by verifying it with a public $key
      * and the token is not expired.
      *

--- a/tests/Namshi/JOSE/Test/SimpleJWSTest.php
+++ b/tests/Namshi/JOSE/Test/SimpleJWSTest.php
@@ -24,7 +24,6 @@ class SimpleJWSTest extends TestCase
     public function testConstruction()
     {
         $this->assertSame($this->jws->getHeader(), array('alg' => 'RS256', 'typ' => 'JWS'));
-        $this->assertTrue(is_int($this->jws->getPayload()['iat']), 'iat property should be integer value (from construction)');
     }
 
     public function testValidationOfAValidSimpleJWS()


### PR DESCRIPTION
fix #111 
As mentioned in RFC7519, iat is an optional claim.
If iat is added in payload, token that does not contains iat will never pass signature verification.