### PR TITLE
Support for a custom json encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,13 @@ vulnerability. More info [here](http://tech.namshi.com/blog/2015/02/19/update-yo
 ## Using a custom encoder
 
 If, for some reason, you need to encode the token in a different way, you can
-inject any implementation of `Namshi\JOSE\Base64\Encoder` in a `JWS` instance.
+inject any implementation of `Namshi\JOSE\Encoder\Encoder` in a `JWS` instance.
 Likewise, `JWS::load()` accepts such an implementation as a second argument.
+
+### Using a custom json encoder
+The token is a base64 encoded json. If you want to control how the json is
+encoded, you can inject a custom json encoder using: `JWS::setJsonEncoder()`
+which takes an instance of `Namshi\JOSE\Encoder\Encoder`.
 
 ## Implementation Specifics
 

--- a/src/Namshi/JOSE/Encoder/Base64Encoder.php
+++ b/src/Namshi/JOSE/Encoder/Base64Encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namshi\JOSE\Base64;
+namespace Namshi\JOSE\Encoder;
 
 class Base64Encoder implements Encoder
 {

--- a/src/Namshi/JOSE/Encoder/Base64UrlSafeEncoder.php
+++ b/src/Namshi/JOSE/Encoder/Base64UrlSafeEncoder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namshi\JOSE\Base64;
+namespace Namshi\JOSE\Encoder;
 
 class Base64UrlSafeEncoder implements Encoder
 {

--- a/src/Namshi/JOSE/Encoder/Encoder.php
+++ b/src/Namshi/JOSE/Encoder/Encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namshi\JOSE\Base64;
+namespace Namshi\JOSE\Encoder;
 
 interface Encoder
 {

--- a/src/Namshi/JOSE/Encoder/JsonEncoder.php
+++ b/src/Namshi/JOSE/Encoder/JsonEncoder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Namshi\JOSE\Encoder;
+
+class JsonEncoder implements Encoder
+{
+    /**
+     * @param string $data
+     *
+     * @return string
+     */
+    public function encode($data)
+    {
+        return json_encode($data, JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return string
+     */
+    public function decode($data)
+    {
+        return json_decode($data, true);
+    }
+}

--- a/src/Namshi/JOSE/JWT.php
+++ b/src/Namshi/JOSE/JWT.php
@@ -2,8 +2,9 @@
 
 namespace Namshi\JOSE;
 
-use Namshi\JOSE\Base64\Base64UrlSafeEncoder;
-use Namshi\JOSE\Base64\Encoder;
+use Namshi\JOSE\Encoder\Base64UrlSafeEncoder;
+use Namshi\JOSE\Encoder\JsonEncoder;
+use Namshi\JOSE\Encoder\Encoder;
 
 /**
  * Class representing a JSON Web Token.
@@ -23,7 +24,12 @@ class JWT
     /**
      * @var Encoder
      */
-    protected $encoder;
+    protected $base64Encoder;
+
+    /**
+     * @var Encoder
+     */
+    protected $jsonEncoder;
 
     /**
      * Constructor.
@@ -35,15 +41,35 @@ class JWT
     {
         $this->setPayload($payload);
         $this->setHeader($header);
-        $this->setEncoder(new Base64UrlSafeEncoder());
+        $this->setBase64Encoder(new Base64UrlSafeEncoder());
+        $this->setJsonEncoder(new JsonEncoder());
     }
 
     /**
      * @param Encoder $encoder
      */
+    public function setBase64Encoder(Encoder $encoder)
+    {
+        $this->base64Encoder = $encoder;
+
+        return $this;
+    }
+
+    /**
+     * @param Encoder $encoder
+     * @deprecated Use setBase64Encoder()
+     */
     public function setEncoder(Encoder $encoder)
     {
-        $this->encoder = $encoder;
+        return $this->setBase64Encoder($encoder);
+    }
+
+    /**
+     * @param Encoder $encoder
+     */
+    public function setJsonEncoder(Encoder $encoder)
+    {
+        $this->jsonEncoder = $encoder;
 
         return $this;
     }
@@ -55,8 +81,10 @@ class JWT
      */
     public function generateSigninInput()
     {
-        $base64payload = $this->encoder->encode(json_encode($this->getPayload(), JSON_UNESCAPED_SLASHES));
-        $base64header = $this->encoder->encode(json_encode($this->getHeader(), JSON_UNESCAPED_SLASHES));
+        $payload = $this->jsonEncoder->encode($this->getPayload());
+        $base64payload = $this->base64Encoder->encode($payload);
+        $header = $this->jsonEncoder->encode($this->getHeader());
+        $base64header = $this->base64Encoder->encode($header);
 
         return sprintf('%s.%s', $base64header, $base64payload);
     }

--- a/tests/Namshi/JOSE/Test/BCJWSTest.php
+++ b/tests/Namshi/JOSE/Test/BCJWSTest.php
@@ -2,7 +2,7 @@
 
 namespace Namshi\JOSE\Test;
 
-use Namshi\JOSE\Base64\Base64Encoder;
+use Namshi\JOSE\Encoder\Base64Encoder;
 use Namshi\JOSE\JWS;
 use PHPUnit_Framework_TestCase as TestCase;
 

--- a/tests/Namshi/JOSE/Test/JWSTest.php
+++ b/tests/Namshi/JOSE/Test/JWSTest.php
@@ -7,7 +7,7 @@ use Namshi\JOSE\JWS;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Namshi\JOSE\Signer\OpenSSL\HS256;
-use Namshi\JOSE\Base64\Base64UrlSafeEncoder;
+use Namshi\JOSE\Encoder\Base64UrlSafeEncoder;
 
 class JWSTest extends TestCase
 {
@@ -135,7 +135,7 @@ class JWSTest extends TestCase
 
     public function testUseOfCustomEncoder()
     {
-        $encoder = $this->prophesize('Namshi\JOSE\Base64\Encoder');
+        $encoder = $this->prophesize('Namshi\JOSE\Encoder\Encoder');
         $encoder
             ->decode(Argument::any())
             ->willReturn('{"whatever": "the payload should be"}')

--- a/tests/Namshi/JOSE/Test/JWTTest.php
+++ b/tests/Namshi/JOSE/Test/JWTTest.php
@@ -2,7 +2,8 @@
 
 namespace Namshi\JOSE\Test;
 
-use Namshi\JOSE\Base64\Base64UrlSafeEncoder;
+use Namshi\JOSE\Encoder\Base64UrlSafeEncoder;
+use Namshi\JOSE\Encoder\JsonEncoder;
 use Namshi\JOSE\JWT;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -13,17 +14,19 @@ class JWTTest extends TestCase
         $payload = array('b' => 'a', 'iat' => 1421161177);
         $header = array('a' => 'b');
         $jwt = new JWT($payload, $header);
-        $encoder = new Base64UrlSafeEncoder();
+        $base64Encoder = new Base64UrlSafeEncoder();
+        $jsonEncoder = new JsonEncoder();
 
-        $this->assertEquals(sprintf('%s.%s', $encoder->encode(json_encode($header)), $encoder->encode(json_encode($payload))), $jwt->generateSigninInput());
+        $this->assertEquals(sprintf('%s.%s', $base64Encoder->encode($jsonEncoder->encode($header)), $base64Encoder->encode($jsonEncoder->encode($payload))), $jwt->generateSigninInput());
     }
 
     public function testGenerationOfTheSigninInputCanHandleSlashes()
     {
-        $encoder = new Base64UrlSafeEncoder();
+        $base64Encoder= new Base64UrlSafeEncoder();
+        $jsonEncoder = new JsonEncoder();
         $json_string = '{"a":"/b/"}';
-        $encoded_json_string = $encoder->encode($json_string);
-        $jwt = new JWT(json_decode($json_string, true), json_decode($json_string, true));
+        $encoded_json_string = $base64Encoder->encode($json_string);
+        $jwt = new JWT($jsonEncoder->decode($json_string), $jsonEncoder->decode($json_string));
 
         $this->assertEquals(sprintf('%s.%s', $encoded_json_string, $encoded_json_string), $jwt->generateSigninInput());
     }


### PR DESCRIPTION
The current implementation relies on the native php functions for encoding/decoding json. The flags provided are `JSON_UNESCAPED_SLASHES`.

Depending on who creates the access token, the json encoding rules might be different. I have a case where I am getting an access token from Microsoft and the special characters are not encoded in json strings, and hence I have to use `JSON_UNESCAPED_UNICODE` as well.

This commit supports injecting a custom Json encoder.

Then main changes are:

- All places that refer to `encoder` have been renamed to `base64Encoder`
- Methods `setEncoder` are renamed to `setBase64Encoder`
- namespace `\Namshi\JOSE\Base64` is moved to `\Namshi\JOSE\Encoder` to support json encoders along with other encoders
- The default `JsonEncoder` class is added